### PR TITLE
enable input for currentValue

### DIFF
--- a/src/components/Model/NodeSummary.vue
+++ b/src/components/Model/NodeSummary.vue
@@ -62,11 +62,11 @@
         </div>
         <div v-else class="text-negative">{{ parserError }}</div>
         <q-input
-          v-if="false"
           v-model="nodeToSubmit.currentValue"
-          label="Current value"
+          label="Current value (optional)"
           type="number"
           :suffix="nodeToSubmit.unit"
+          hint="Only used if a delay function with 'best_guess' as initial value references this node."
           debounce="300"
         />
         <div v-if="nodeChart.chartData.length > 0">


### PR DESCRIPTION
## Proposed Changes
<!--- Describe your changes in detail -->
  - Allow user to input optional "current value" for a node, which is only used when a delay function with "best_guess" initial value is references this node.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
### Before this PR

### After this PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
