### PR TITLE
fix mouse wheel zoom after upgrading to d3 v6

### DIFF
--- a/src/components/Model/DependencyGraph.vue
+++ b/src/components/Model/DependencyGraph.vue
@@ -272,8 +272,13 @@ export default {
     this.zoom = d3
       .zoom()
       .scaleExtent([1 / 4, 2])
+      .wheelDelta(myDelta)
       .on("zoom", this.zoomed);
     svg.call(this.zoom);
+
+    function myDelta(event) {
+      return (-event.deltaY * (event.deltaMode ? 120 : 1)) / 1500;
+    }
 
     //require ctrlKey in addition to mouse
     this.zoom.filter(function(event, d) {


### PR DESCRIPTION
## Proposed Changes
<!--- Describe your changes in detail -->
  - Add a custom function for d3-zoom wheelDelta, to fix zoom steps being too big, noticed after upgrade to d3 v6.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
